### PR TITLE
Column Sorting & Fix exemple with 1.01 version

### DIFF
--- a/addons/AnomalyAcesTable/Demos/BasicExemple.gd
+++ b/addons/AnomalyAcesTable/Demos/BasicExemple.gd
@@ -5,8 +5,8 @@ extends Control
 # Declare member variables here. Examples:
 # var a = 2
 # var b = "text"
-var table: TableManager.Table
-var tablePlugin: TableManager.Plugin
+var table: Table
+var tablePlugin: TablePlugin
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
@@ -15,6 +15,7 @@ func _ready():
 		"foo":{
 			"columnId": "foo",
 			"columnName": "Foo",
+			"columnSort": true,
 			"columnType": TableConstants.ColumnType.LABEL,
 						"columnAlign": TableConstants.Align.CENTER
 		},
@@ -41,6 +42,18 @@ func _ready():
 			"foobar": "res://icon.png"
 		}
 	
+	var data2 = {
+			"foo":"15",
+			"bar":"Press Me",
+			"foobar": "res://icon.png"
+		}
+		
+	var data3 = {
+			"foo":"11",
+			"bar":"Press Me",
+			"foobar": "res://icon.png"
+		}
+	
 	var textRect = TextureRect.new()
 	textRect.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_CENTERED
 	textRect.size_flags_horizontal = SIZE_EXPAND_FILL
@@ -49,9 +62,9 @@ func _ready():
 		"textureRect": textRect
 	}
 	
-	var tblConfig : TableManager.Config = TableManager.createTableConfig(colDefs, data)
+	var tblConfig : TableConfig = TableManager.createTableConfig(colDefs, data)
 	table = TableManager.createTable(tablePlugin, tblConfig)
-	TableManager.setTableData(table, [data, data, data])
+	TableManager.setTableData(table, [data, data2, data3])
 	
 	print(tablePlugin.to_string())
 

--- a/addons/AnomalyAcesTable/Scripts/Helper/Table.gd
+++ b/addons/AnomalyAcesTable/Scripts/Helper/Table.gd
@@ -75,7 +75,7 @@ func _createColumnHeaders():
 		
 		if colDef.columnSort:
 			node_header = Button.new()
-			(node_header as Button).connect("pressed", _sorter, "sort_row_by_column", [self, col_key, TableConstants.ColumnSort.SORT_ASCENDING])
+			(node_header as Button).connect("pressed", self, "_on_column_header_pressed_ascending", [node_header, col_key])
 		else:
 			node_header = Label.new()
 			node_header.valign = Label.VALIGN_CENTER
@@ -104,3 +104,16 @@ func set_data(dataArr:Array):
 
 func get_rows():
 	return _rowContainer.get_children()
+	
+
+func _on_column_header_pressed_ascending(node_header, col_key):
+	_sorter.sort_row_by_column(self, col_key, TableConstants.ColumnSort.SORT_ASCENDING)
+
+	node_header.disconnect("pressed", self, "_on_column_header_pressed_ascending")
+	node_header.connect("pressed", self, "_on_column_header_pressed_descending", [node_header, col_key])
+
+func _on_column_header_pressed_descending(node_header, col_key):
+	_sorter.sort_row_by_column(self, col_key, TableConstants.ColumnSort.SORT_DESCENDING)
+	
+	node_header.disconnect("pressed", self, "_on_column_header_pressed_descending")
+	node_header.connect("pressed", self, "_on_column_header_pressed_ascending", [node_header, col_key])

--- a/addons/AnomalyAcesTable/Scripts/Helper/Table.gd
+++ b/addons/AnomalyAcesTable/Scripts/Helper/Table.gd
@@ -3,6 +3,7 @@ class_name Table, "res://addons/AnomalyAcesTable/Scripts/Helper/NoIcon.svg"
 
 var _row = load("res://addons/AnomalyAcesTable/Scenes/Row.tscn")
 var _table = load("res://addons/AnomalyAcesTable/Scenes/Table.tscn")
+var _sorter = load("res://addons/AnomalyAcesTable/Scripts/Helper/TableSorter.gd").new()
 
 #Column Headers
 var _columnHeaderContainer: HBoxContainer
@@ -69,14 +70,21 @@ func _createColumnHeaders():
 	for col_key in tableConfig.columnDefs:
 		var colDict = tableConfig.columnDefs[col_key]
 		var colDef: TableColumnDef = TableColumnDef.new(colDict)
-	
-		var label = Label.new()
-		label.text = colDef.columnName
-		label.name = colDef.columnId
-		label.size_flags_horizontal = SIZE_EXPAND_FILL
-		label.valign = Label.VALIGN_CENTER
-		label.align = colDef.columnAlign
-		_columnHeaderContainer.add_child(label)
+		
+		var node_header: Control
+		
+		if colDef.columnSort:
+			node_header = Button.new()
+			(node_header as Button).connect("pressed", _sorter, "sort_row_by_column", [self, col_key, TableConstants.ColumnSort.SORT_ASCENDING])
+		else:
+			node_header = Label.new()
+			node_header.valign = Label.VALIGN_CENTER
+		
+		node_header.text = colDef.columnName
+		node_header.name = colDef.columnId
+		node_header.size_flags_horizontal = SIZE_EXPAND_FILL
+		node_header.align = colDef.columnAlign
+		_columnHeaderContainer.add_child(node_header)
 	
 #	var blankLabel = Label.new()
 #	blankLabel.name = "Blank"
@@ -91,4 +99,8 @@ func set_data(dataArr:Array):
 		rowScene.set_theme(plugin.table_row_cell_theme)
 		_rowContainer.add_child(rowScene)
 		
-		TableRow.new(plugin, tableConfig, dataArr[dataIdx], rowScene)
+		rowScene.setup(plugin, tableConfig, dataArr[dataIdx], rowScene)
+
+
+func get_rows():
+	return _rowContainer.get_children()

--- a/addons/AnomalyAcesTable/Scripts/Helper/Table.gd
+++ b/addons/AnomalyAcesTable/Scripts/Helper/Table.gd
@@ -94,13 +94,13 @@ func _createColumnHeaders():
 
 
 func set_data(dataArr:Array):
-	var rowScene = _row.instance()
 	for dataIdx in dataArr.size():
+		var rowScene = _row.instance()
 		rowScene.name = "Row"+str(dataIdx)
 		rowScene.set_theme(plugin.table_row_cell_theme)
 		_rowContainer.add_child(rowScene)
 		
-		rowScene.setup(plugin, tableConfig, dataArr[dataIdx], rowScene)
+		TableRow.new(plugin, tableConfig, dataArr[dataIdx], rowScene)
 
 
 func get_rows():

--- a/addons/AnomalyAcesTable/Scripts/Helper/TableColumnDef.gd
+++ b/addons/AnomalyAcesTable/Scripts/Helper/TableColumnDef.gd
@@ -6,6 +6,7 @@ const INVALID_TYPE: int = -1
 var columnName: String
 var columnId: String
 var columnType: int
+var columnSort: bool = false
 var columnAlign: int
 var columnImage: String
 var columnFunc: FuncRef
@@ -21,6 +22,8 @@ func _init(colDef: Dictionary):
 		else:
 			columnType = TableConstants.ColumnType.LABEL
 		
+		if(colDef.has("columnSort")):
+			columnSort = colDef.columnSort
 		if(colDef.has("columnImage") && !colDef.columnImage.empty()):
 			columnImage = colDef.columnImage
 		if(colDef.has("columnFunc") && colDef.columnFunc != null):

--- a/addons/AnomalyAcesTable/Scripts/Helper/TableConstants.gd
+++ b/addons/AnomalyAcesTable/Scripts/Helper/TableConstants.gd
@@ -6,6 +6,12 @@ enum ColumnType {
 	TEXTURE_RECT
 }
 
+enum ColumnSort {
+	NONE,
+	SORT_ASCENDING,
+	SORT_DESCENDING
+}
+
 enum Align {
 	LEFT,
 	CENTER,

--- a/addons/AnomalyAcesTable/Scripts/Helper/TableRow.gd
+++ b/addons/AnomalyAcesTable/Scripts/Helper/TableRow.gd
@@ -6,8 +6,12 @@ signal pressed
 var _cellContainer: HBoxContainer
 
 var colDefs: Array = []
+var data: Dictionary
 
-func _init(plugin:TablePlugin, tblCfg: TableConfig, dt: Dictionary, rowScene: PanelContainer):
+
+func setup(plugin: TablePlugin, tblCfg: TableConfig, dt: Dictionary, rowScene: PanelContainer):
+	
+	rowScene.data = dt
 	
 	_cellContainer = rowScene.get_node("MarginContainer/Row")
 	_cellContainer.add_constant_override("separation", plugin.table_cell_separation)

--- a/addons/AnomalyAcesTable/Scripts/Helper/TableRow.gd
+++ b/addons/AnomalyAcesTable/Scripts/Helper/TableRow.gd
@@ -17,7 +17,7 @@ func _init(plugin:TablePlugin=null, tblCfg: TableConfig=null, dt: Dictionary = {
 	if(plugin == null || tblCfg == null || rowScene == null):
 		return
 
-  rowScene.data = dt
+	rowScene.data = dt
 	
 	_cellContainer = rowScene.get_node("MarginContainer/Row")
 	_cellContainer.add_constant_override("separation", plugin.table_cell_separation)

--- a/addons/AnomalyAcesTable/Scripts/Helper/TableSorter.gd
+++ b/addons/AnomalyAcesTable/Scripts/Helper/TableSorter.gd
@@ -1,0 +1,51 @@
+class_name TableSorter
+
+var inner_column_name : String
+
+func sort_row_by_column(table, column_name: String, sorting_type):
+	### Check ###
+	if sorting_type == TableConstants.ColumnSort.NONE:
+			push_warning("Sorting called but filter method is None")
+			return
+	
+	### Init sorting and get data ###
+	inner_column_name = column_name
+	
+	var rows: Array = table.get_rows()
+	var rows_data: Array = []
+	var rows_data_to_row: Dictionary
+	
+	
+	for row in rows:
+		rows_data.append(row.data)
+		rows_data_to_row[row.data] = row
+	
+	### Sort data ###
+	match sorting_type:
+		TableConstants.ColumnSort.SORT_ASCENDING:
+			rows_data.sort_custom(self, "_sort_ascending")
+		
+		TableConstants.ColumnSort.SORT_DESCENDING:
+			rows_data.sort_custom(self, "_sort_descending")
+			
+	### Sort rows ###
+	var rows_parent: Node = table._rowContainer
+	
+	for i in range(rows_data.size()):
+		var row = rows_data_to_row[rows_data[i]]
+		rows_parent.move_child(row, i)
+		
+
+
+func _sort_ascending(a, b):
+	if a[inner_column_name] < b[inner_column_name]:
+		return true
+	
+	return false
+
+
+func _sort_descending(a, b):
+	if a[inner_column_name] > b[inner_column_name]:
+		return true
+	
+	return false


### PR DESCRIPTION
Fix Exemple with 1.01 version with new class_name

Add new column sorting:
- header as button
- ascending/descending
- TableSorter class file

Also rename init to setup on TableRow:
fix a bug with

>  _row.instance()

 which lead to row not having script

